### PR TITLE
Use MRB_ARGS_OPT(1) instead of MRB_ARGS_NONE()

### DIFF
--- a/src/mrb_userdata.c
+++ b/src/mrb_userdata.c
@@ -102,7 +102,7 @@ void mrb_mruby_userdata_gem_init(mrb_state *mrb)
   struct RClass *userdata;
 
   userdata = mrb_define_class(mrb, "Userdata", mrb->object_class);
-  mrb_define_method(mrb, userdata, "initialize", mrb_userdata_init, MRB_ARGS_NONE());
+  mrb_define_method(mrb, userdata, "initialize", mrb_userdata_init, MRB_ARGS_OPT(1));
   mrb_define_method(mrb, userdata, "method_missing", mrb_userdata_method_missing, MRB_ARGS_ANY());
   DONE;
 


### PR DESCRIPTION
mruby v2.0.1 was ignoring "MRB_ARGS_NONE"
but mruby v2.1.0 raise an error like this:
>‘initialize’: wrong number of arguments (1 for 0) (ArgumentError)

I think "initialize" accept 1 arg for "mrb_userdata_key_store"
so MRB_ARGS_OPT(1) is appropriate.

## Back Ground
Let me explain the background.
When I used ngx_mruby v2.2.0(includes mruby v2.1.0), we faced to the error:
>‘initialize’: wrong number of arguments (1 for 0) (ArgumentError)

nginx.conf

```
mruby_init_code '
    require "/etc/nginx/handler.d/redirector_init.rb"
';
```

redirector_init.rb

```ruby
15: ru = Userdata.new('redirector')
```

And I saw the code:
https://github.com/matsumotory/mruby-userdata/blob/master/src/mrb_userdata.c#L105

As I wrote as commit message, `initialize` accepts optional 1 argument.
from mruby v2.1.0, it is handled strictly.

@matsumotory 
Could you review it?
